### PR TITLE
[SEC-1341] Add SBT Dependency Graph submission workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,11 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches: ["master", "main", "dev"]
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: scalacenter/sbt-dependency-submission@v3


### PR DESCRIPTION

# Description

This PR will add a Github action to submit the dependency graph of an sbt build to the Github Dependency submission API. This will allow Dependabot to scan dependencies and raise alerts and security updates for any known vulnerabilities.

For futher informaiton on the Github Action - [sbt-dependency-submission](https://github.com/scalacenter/sbt-dependency-submission)